### PR TITLE
fix: examples/boxes.cpp performance and more

### DIFF
--- a/examples/boxes.cpp
+++ b/examples/boxes.cpp
@@ -24,40 +24,42 @@ struct coord {
     bool operator==(const coord& other) const { return (this->row == other.row && this->col == other.col); }
 };
 
+// make `x` be good for `counter_box`
+void count(const unsigned long long& x) {
+    unsigned r = 0;
+    if (x % 100 == 0) {
+        std::cout << tui::tui_string(x / 100).on_red().black();
+    } else if (x % 10 == 0) {
+        std::cout << tui::tui_string(x / 10 % 10).on_blue().black();
+    } else {
+        std::cout << x % 10;
+    }
+}
+
 void counter_box(coord start, coord end) {
     assert(start.row <= end.row && start.col <= end.col);
 
-    tui::cursor::set_position(start.row, start.col);
-
     // do rows
-    for (auto row = start.row; row <= end.row; ++row) {
+    // from top to down
+    for (auto row = start.row + 1; row < end.row; ++row) {
+        // left row
         tui::cursor::set_position(row, start.col);
-        if (row % 10 == 0) {
-            std::cout << tui::tui_string(tui::text::concat(row / 10)).on_magenta();
-        } else {
-            std::cout << row % 10;
-        }
+        count(row);
+        // right row
         tui::cursor::set_position(row, end.col);
-        if (row % 10 == 0) {
-            std::cout << tui::tui_string(tui::text::concat(row / 10)).on_magenta();
-        } else {
-            std::cout << row % 10;
-        }
+        count(row);
     }
+
     // do columns
-    for (auto col = start.col + 1; col < end.col; ++col) {
-        tui::cursor::set_position(start.row, col);
-        if (col % 10 == 0) {
-            std::cout << tui::tui_string(tui::text::concat(col / 10)).on_magenta();
-        } else {
-            std::cout << col % 10;
-        }
-        tui::cursor::set_position(end.row, col);
-        if (col % 10 == 0) {
-            std::cout << tui::tui_string(tui::text::concat(col / 10)).on_magenta();
-        } else {
-            std::cout << col % 10;
-        }
+    // top left
+    tui::cursor::set_position(start.row, start.col);
+    for (auto col = start.col; col <= end.col; ++col) {
+        count(col);
+    }
+    // bottom left
+    tui::cursor::set_position(end.row, start.col);
+    for (auto col = start.col; col <= end.col; ++col) {
+        count(col);
     }
 }
 
@@ -230,7 +232,7 @@ void run() {
         tui::cursor::set_position(msg_start.row, msg_start.col);
         std::cout << msg.bold().italic().inverted().blue();
 
-        tui::cursor::set_position(38, 140);
+        tui::cursor::set_position(screen.row / 3 * 2, screen.col / 3 * 2);
         std::cout << tui::tui_string("tui.hpp").bold().blue().link("https://github.com/csboo/cpptui").on_magenta();
         // tui::cursor::set_position(39, 140);
         // std::cout << "\\──────┘";

--- a/examples/boxes.cpp
+++ b/examples/boxes.cpp
@@ -120,6 +120,38 @@ void box(coord start, coord end, kind with) {
     std::cout << draw[3];
 }
 
+// catch special characters, that might mess up things
+void filter_chars(char ch) {
+    if (ch < 0) {
+        std::cin.ignore();
+        ch = 0;
+    } else if (ch == 27 && std::cin.peek() == 91) {
+        tui::cursor::set_position(40, 140 - 2);
+        std::cin.ignore();
+        auto sus = std::cin.get();
+        std::cout << "oh! an arrow? ";
+        switch (sus) {
+        case 65:
+            std::cout << "up   ";
+            break;
+        case 66:
+            std::cout << "down ";
+            break;
+        case 67:
+            std::cout << "right";
+            break;
+        case 68:
+            std::cout << "left ";
+            break;
+        default:
+            std::cout << "NO!  ";
+            std::cin.get();
+            std::cin.get();
+            std::cin.ignore();
+            break;
+        }
+    }
+}
 void run() {
     auto screen_size = tui::screen::size();
     auto screen = coord{screen_size.first, screen_size.second};
@@ -142,32 +174,6 @@ void run() {
 
     char x = 0;
     while (x != 'q') {
-        if (x == 27 && std::cin.peek() == 91) {
-            tui::cursor::set_position(40, 140 - 2);
-            std::cin.ignore();
-            auto sus = std::cin.get();
-            std::cout << "oh! an arrow? ";
-            switch (sus) {
-            case 65:
-                std::cout << "up   ";
-                break;
-            case 66:
-                std::cout << "down ";
-                break;
-            case 67:
-                std::cout << "right";
-                break;
-            case 68:
-                std::cout << "left ";
-                break;
-            default:
-                std::cout << "NO!  ";
-                std::cin.get();
-                std::cin.get();
-                std::cin.ignore();
-                break;
-            }
-        }
 
         screen_size = tui::screen::size();
         screen = coord{screen_size.first, screen_size.second};
@@ -245,10 +251,7 @@ void run() {
         // 120fps
         std::this_thread::sleep_for(std::chrono::milliseconds(8));
         std::cin.get(x);
-        if (x < 0) {
-            std::cin.ignore();
-            x = 0;
-        }
+        filter_chars(x);
     }
 }
 

--- a/examples/boxes.cpp
+++ b/examples/boxes.cpp
@@ -86,7 +86,7 @@ std::unordered_map<kind, std::vector<std::string>> kinds() {
 // |                              |
 // |                              |
 // end.row ---------------- end.col
-void box(coord start, coord end, kind with) {
+void draw_box(coord start, coord end, kind with) {
     assert(start.row <= end.row && start.col <= end.col);
 
     auto draw = kinds()[with];
@@ -189,27 +189,27 @@ void run() {
             }
         } else if (x == 'j') {
             auto* cb = &boxes[current_box];
-            box(cb->first, cb->second, empty);
+            draw_box(cb->first, cb->second, empty);
             cb->first.row++;
             cb->second.row++;
         } else if (x == 'k') {
             auto* cb = &boxes[current_box];
-            box(cb->first, cb->second, empty);
+            draw_box(cb->first, cb->second, empty);
             cb->first.row--;
             cb->second.row--;
         } else if (x == 'h') {
             auto* cb = &boxes[current_box];
-            box(cb->first, cb->second, empty);
+            draw_box(cb->first, cb->second, empty);
             cb->first.col--;
             cb->second.col--;
         } else if (x == 'l') {
             auto* cb = &boxes[current_box];
-            box(cb->first, cb->second, empty);
+            draw_box(cb->first, cb->second, empty);
             cb->first.col++;
             cb->second.col++;
         } else if (x == '-') {
             auto* cb = &boxes[current_box];
-            box(cb->first, cb->second, empty);
+            draw_box(cb->first, cb->second, empty);
             cb->first.row++;
             cb->first.col++;
 
@@ -217,7 +217,7 @@ void run() {
             cb->second.col--;
         } else if (x == '+') {
             auto* cb = &boxes[current_box];
-            box(cb->first, cb->second, empty);
+            draw_box(cb->first, cb->second, empty);
             cb->first.row--;
             cb->first.col--;
 
@@ -228,10 +228,10 @@ void run() {
         for (auto item : boxes) {
             if (item == boxes[current_box]) {
                 std::cout << tui::text::color::cyan_fg();
-                box(item.first, item.second, rounded);
+                draw_box(item.first, item.second, rounded);
                 std::cout << tui::text::style::reset_style();
             } else {
-                box(item.first, item.second, basic);
+                draw_box(item.first, item.second, basic);
             }
         }
 

--- a/examples/tui_string_size.cpp
+++ b/examples/tui_string_size.cpp
@@ -1,0 +1,15 @@
+#include "../tui.hpp"
+#include <fstream>
+
+int main() {
+    std::string orig = "0123456789";
+    auto styled = tui::tui_string(orig).on_green().italic().inverted().rgb(100, 100, 100).link("https://codeberg.org");
+
+    std::ofstream fout("test.txt");
+    fout << "\"" << orig << "\"" << orig.size() << "\n";
+    fout << "\"" << styled << "\"" << styled.size() << "\n";
+    fout.close();
+
+    std::cout << "hello";
+    return 0;
+}


### PR DESCRIPTION
- `counter_box()` doesn't make the cursor jump around so much crazily
- it handles 100-s correctly 
- tui.hpp msg now has a relative position