### PR TITLE
scroll input on non-windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Uses macro magic (not intentionally, but it's needed to reduce code size and ove
 -   raw mode
 -   alternate screen
 -   performant screen size query
--   custom function for resize handling, NOTE: you should probably lock `stdout`, stdin when you use this feature, also, **doesn't work on Windows**
+-   custom function for resize handling, **_NOTE_**: you should probably lock `stdout`, stdin when you use this feature, also, **doesn't work on Windows**
 
 ### input
 
@@ -34,9 +34,11 @@ a pretty handy header with functions and types to improve reading input from `st
 -   basic symbols, such as `['~', ';', '*', ...]`, but not `['$', '€', ...]`
 -   <kbd>Ctrl</kbd>`+alphabetical characters`
 -   arrows
+-   touchpad/mouse scroll
 -   <kbd>Backspace</kbd>, <kbd>(Shift)Tab</kbd>, <kbd>Enter/Return</kbd>, <kbd>Delete</kbd>, <kbd>Page[Up,Down]</kbd>, <kbd>Home,End</kbd>, <kbd>Insert</kbd>,
 -   <kbd>F[1,2,3,4]</kbd> **_NOTE_**: the other F-keys are damn hard to implement, might be done in the future though
--   basic characters, be it upper or lowercase, special ones like: `['ö', 'ä', 'á', ...]` are safely ignored
+-   basic characters, be it upper or lowercase
+-   **_NOTE_**: special ones like: `['ö', 'ä', 'á', ...]` are safely ignored
 
 ### coordinates
 
@@ -94,7 +96,7 @@ int main() {
 
 ## non-goals
 
--   mouse support
+-   full mouse support
 -   huge number of widgets
 -   high level functions
 -   thousands of more features: just what's necessary

--- a/input.hpp
+++ b/input.hpp
@@ -193,9 +193,7 @@ struct Input {
 #ifndef _WIN32
             char next_byte = get_char();
 
-            switch (next_byte) {
-            case 79:
-            case 91: {
+            if (next_byte == 79 || next_byte == 91) {
                 char special = get_char();
                 switch (special) {
                 case Arrow::Up:
@@ -221,18 +219,13 @@ struct Input {
                     input = Input(static_cast<SpecKey>(special));
                     break;
                 default:
-                    // ignore_byte = _getch(3);
+                    // ignore_byte = get_char();
                     break;
                 }
                 break;
             }
-
-            default:
-                input = Input(SpecKey::Esc);
-            }
-#else
-            input = Input(SpecKey::Esc);
 #endif
+            input = Input(SpecKey::Esc);
         }
         default:
             break;

--- a/input.hpp
+++ b/input.hpp
@@ -240,21 +240,17 @@ struct Input {
         char tmp = _getch();
         return tmp;
     }
-    static Input read() {
-        // read raw input
-        return Input::read_helper(Input::read_ch);
-    }
 #else // not windows
     static char read_ch() {
         char tmp = 0;
         ::read(STDIN_FILENO, &tmp, 1);
         return tmp;
     }
+#endif
     static Input read() {
         // read raw input
         return Input::read_helper(Input::read_ch);
     }
-#endif
 };
 
 inline std::ostream& operator<<(std::ostream& os, const Input& inp) {

--- a/input.hpp
+++ b/input.hpp
@@ -203,6 +203,7 @@ struct Input {
             char next_byte = get_char();
 
             switch (next_byte) {
+            case 79:
             case 91: {
                 char special = get_char();
                 switch (special) {
@@ -212,6 +213,10 @@ struct Input {
                 case Arrow::Left:
                     input = Input(static_cast<Arrow>(special));
                     break;
+                case SpecKey::F1:
+                case SpecKey::F2:
+                case SpecKey::F3:
+                case SpecKey::F4:
                 case SpecKey::End:
                 case SpecKey::Home:
                 case SpecKey::ShiftTab:
@@ -230,21 +235,7 @@ struct Input {
                 }
                 break;
             }
-            case 79: {
-                // get function key character
-                char f_key = get_char();
-                switch (f_key) {
-                case SpecKey::F1:
-                case SpecKey::F2:
-                case SpecKey::F3:
-                case SpecKey::F4:
-                    input = Input(static_cast<SpecKey>(f_key));
-                    break;
-                default:
-                    break;
-                }
-                break;
-            }
+
             default:
                 input = Input(SpecKey::Esc);
             }

--- a/input.hpp
+++ b/input.hpp
@@ -13,14 +13,6 @@
 #include <unistd.h>  // For read(), usleep() on Unix-like systems
 #endif
 
-// Function to set stdin non-blocking on Unix-like systems
-#ifndef _WIN32
-inline void set_non_blocking(bool enable) {
-    int flags = fcntl(STDIN_FILENO, F_GETFL, 0);
-    fcntl(STDIN_FILENO, F_SETFL, enable ? flags | O_NONBLOCK : flags & ~O_NONBLOCK);
-}
-#endif
-
 // sorry for this ugly code, I really feel very bad about it.
 // damn macros, because given `MyEnum::Core` you can't do
 // `cout << MyEnum::Core; assert(cout.string() == "Core"|"MyEnum::Core")`
@@ -199,7 +191,6 @@ struct Input {
             break;
         case SpecKey::Esc: {
 #ifndef _WIN32
-            set_non_blocking(false); // Temporarily make stdin non-blocking
             char next_byte = get_char();
 
             switch (next_byte) {
@@ -239,7 +230,6 @@ struct Input {
             default:
                 input = Input(SpecKey::Esc);
             }
-            set_non_blocking(false); // Temporarily make stdin non-blocking
 #else
             input = Input(SpecKey::Esc);
 #endif


### PR DESCRIPTION
## description
add support for scroll input for non-windows operating-systems
fixes #42

## Changelog

- **fix(input): recognize scroll on unix-like systems as well**
- **refactor(input): seems like set_non_blocking is unnecessary**
- **refactor(input): simplify code**
- **refactor(input): simplify code**
- **docs: updated**
